### PR TITLE
chore: bump actions and runner version

### DIFF
--- a/.github/workflows/update_databases.yml
+++ b/.github/workflows/update_databases.yml
@@ -5,6 +5,7 @@ on:
     # according to the mtime of the gzip it's created on the first day of the
     # month at 30 minutes past midnight
     - cron: "0 2 1-4 * *"
+  pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/update_databases.yml
+++ b/.github/workflows/update_databases.yml
@@ -11,24 +11,24 @@ on:
 
 jobs:
   update_databases:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: cache inputs and outputs
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: update_databases_inputs_outputs
           path: |
             ~/cache_dir
             ~/outputs
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: ">=1.18.0"
           cache: true
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.9"
           cache: "pip"


### PR DESCRIPTION
I noticed warnings in the actions runs.

While there, turn on the action for pull requests or we'll never know if my changes are good.