### PR TITLE
download_assets.py: set download_latest to false

### DIFF
--- a/download_assets.py
+++ b/download_assets.py
@@ -226,7 +226,7 @@ def main():
     print("[+] downloading GeoIP assets")
     download_ia_assets(cache_dir=cache_dir, download_latest=True)
     print("[+] downloading AS Organizations assets")
-    download_as_organizations(cache_dir=cache_dir, download_latest=True)
+    download_as_organizations(cache_dir=cache_dir, download_latest=False)
 
     days = []
     for path in (cache_dir / "dbip-country-lite").glob("*.mmdb.gz"):


### PR DESCRIPTION
if this script is run after the first of the month but before the mmdb.gz has been published it will obtain no data. If a file is cached, the download is skipped, so this should be safe.

https://github.com/ooni/historical-geoip/issues/23