### PR TITLE
fix: pull in all historic as organizations for json mapping

### DIFF
--- a/download_assets.py
+++ b/download_assets.py
@@ -227,7 +227,7 @@ def main():
     print("[+] downloading GeoIP assets")
     download_ia_assets(cache_dir=cache_dir, download_latest=download_latest)
     print("[+] downloading AS Organizations assets")
-    download_as_organizations(cache_dir=cache_dir, download_latest=download_latest)
+    download_as_organizations(cache_dir=cache_dir, download_latest=False)
 
     days = []
     for path in (cache_dir / "dbip-country-lite").glob("*.mmdb.gz"):


### PR DESCRIPTION
This diff fixes the current state where we only pull in the latest AS organizations from caida and makes use of all historic data to build the `all_as_org_map.json` file