### PR TITLE
correct AS Orgname "changed" records with whois query

### DIFF
--- a/build_all_as_org_map.py
+++ b/build_all_as_org_map.py
@@ -33,7 +33,7 @@ def build_asn_org_map(in_file, day_str):
 
         asn = int(chunks[0])
         changed = chunks[1]
-        if not changed:
+        if not changed or changed == 'latest':
             changed = day_str
         aut_name = chunks[2]
         org_id = chunks[3]

--- a/build_all_as_org_map.py
+++ b/build_all_as_org_map.py
@@ -15,6 +15,8 @@ def build_asn_org_map(in_file, day_str):
     org_id_to_name = {}
 
     is_in_asn_section = False
+
+    num_invalid_changed_field = 0
     for line in in_file:
         line = line.strip()
 
@@ -36,6 +38,8 @@ def build_asn_org_map(in_file, day_str):
         asn = int(chunks[0])
         changed = chunks[1]
         if not changed or changed == 'latest':
+            num_invalid_changed_field += 1
+            print(f"record for AS{asn} contains changed == \"latest\"")
             # upstream data is missing the correct date, query it from whois
             # as of 01-07-2026 there are ~150 AS with "latest" as changed
             try:
@@ -46,7 +50,9 @@ def build_asn_org_map(in_file, day_str):
             except Exception as e:
                 # if this lookup fails, use todays date as a fallback so that
                 # it increments with each release
+                print(f"failed to query AS{asn}, defaulting to now")
                 changed = datetime.now(timezone.utc).strftime("%Y%m%d"))
+            print(f"updated record for AS{asn} changed as {changed}")
         aut_name = chunks[2]
         org_id = chunks[3]
         source = chunks[-1]
@@ -59,6 +65,8 @@ def build_asn_org_map(in_file, day_str):
                 org_id=org_id,
             )
         )
+
+    print(f"detected {num_invalid_changed_field} entries with \"latest\" for changed date")
 
     asn_org_map = {}
     for as_info in as_list:

--- a/build_all_as_org_map.py
+++ b/build_all_as_org_map.py
@@ -1,5 +1,6 @@
 import gzip
-import datetime, timezone
+import datetime
+from datetime import timezone, datetime
 from collections import namedtuple
 import json
 from pathlib import Path

--- a/build_all_as_org_map.py
+++ b/build_all_as_org_map.py
@@ -51,7 +51,7 @@ def build_asn_org_map(in_file, day_str):
                 # if this lookup fails, use todays date as a fallback so that
                 # it increments with each release
                 print(f"failed to query AS{asn}, defaulting to now")
-                changed = datetime.now(timezone.utc).strftime("%Y%m%d"))
+                changed = datetime.now(timezone.utc).strftime("%Y%m%d")
             print(f"updated record for AS{asn} changed as {changed}")
         aut_name = chunks[2]
         org_id = chunks[3]

--- a/build_all_as_org_map.py
+++ b/build_all_as_org_map.py
@@ -1,7 +1,9 @@
 import gzip
+import datetime, timezone
 from collections import namedtuple
 import json
 from pathlib import Path
+import whoisit
 
 
 ASInfo = namedtuple("ASInfo", ["asn", "changed", "aut_name", "source", "org_id"])
@@ -34,7 +36,17 @@ def build_asn_org_map(in_file, day_str):
         asn = int(chunks[0])
         changed = chunks[1]
         if not changed or changed == 'latest':
-            changed = day_str
+            # upstream data is missing the correct date, query it from whois
+            # as of 01-07-2026 there are ~150 AS with "latest" as changed
+            try:
+                r = whoisit.asn(f"AS{asn}")
+                dt = r["last_changed_date"]
+                if isinstance(dt, datetime):
+                    changed = dt.strftime("%Y%m%d")
+            except Exception as e:
+                # if this lookup fails, use todays date as a fallback so that
+                # it increments with each release
+                changed = datetime.now(timezone.utc).strftime("%Y%m%d"))
         aut_name = chunks[2]
         org_id = chunks[3]
         source = chunks[-1]
@@ -74,6 +86,7 @@ def build_asn_org_map(in_file, day_str):
 
 
 def main():
+    whoisit.bootstrap()
     input_dir = Path("cache_dir") / "as-organizations"
     output_dir = Path("outputs")
     output_dir.mkdir(parents=True, exist_ok=True)

--- a/download_assets.py
+++ b/download_assets.py
@@ -235,7 +235,7 @@ def main():
     print("[+] downloading GeoIP assets")
     download_ia_assets(cache_dir=cache_dir, download_latest=download_latest)
     print("[+] downloading AS Organizations assets")
-    download_as_organizations(cache_dir=cache_dir, download_latest=download_latest)
+    download_as_organizations(cache_dir=cache_dir, download_latest=False)
 
     days = []
     for path in (cache_dir / "dbip-country-lite").glob("*.mmdb.gz"):

--- a/download_assets.py
+++ b/download_assets.py
@@ -156,10 +156,10 @@ def download_as_organizations(cache_dir: Path, download_latest: bool):
     since_date = date(2012, 1, 1)
     until_date = datetime.now(timezone.utc).date()
     if download_latest:
-        # Since date = last week (7 days ago)
-        # Use the last weeks worth of publications to straddle the end of the month:
         # It takes about 4 days from the start of the month for the caida data to be published
+        # Include last month if less than seven days have passed
         since_date = until_date - timedelta(days=7)
+        since_date.replace(day=1) # the release day is always 1
 
     for url in iter_as_org_urls(since_date, until_date):
         dst_filename = os.path.basename(url)

--- a/download_assets.py
+++ b/download_assets.py
@@ -4,7 +4,7 @@ import shutil
 import hashlib
 from collections import namedtuple
 from pathlib import Path
-from datetime import datetime, date, timezone
+from datetime import datetime, date, timezone, timedelta
 from typing import Generator, List
 import xml.etree.ElementTree as ET
 
@@ -156,8 +156,10 @@ def download_as_organizations(cache_dir: Path, download_latest: bool):
     since_date = date(2012, 1, 1)
     until_date = datetime.now(timezone.utc).date()
     if download_latest:
-        # Start from the 1st of the current month
-        since_date = until_date.replace(day=1)
+        # Since date = last week (7 days ago)
+        # Use the last weeks worth of publications to straddle the end of the month:
+        # It takes about 4 days from the start of the month for the caida data to be published
+        since_date = until_date - timedelta(days=7)
 
     for url in iter_as_org_urls(since_date, until_date):
         dst_filename = os.path.basename(url)

--- a/download_assets.py
+++ b/download_assets.py
@@ -235,7 +235,7 @@ def main():
     print("[+] downloading GeoIP assets")
     download_ia_assets(cache_dir=cache_dir, download_latest=download_latest)
     print("[+] downloading AS Organizations assets")
-    download_as_organizations(cache_dir=cache_dir, download_latest=False)
+    download_as_organizations(cache_dir=cache_dir, download_latest=download_latest)
 
     days = []
     for path in (cache_dir / "dbip-country-lite").glob("*.mmdb.gz"):

--- a/download_assets.py
+++ b/download_assets.py
@@ -179,11 +179,15 @@ def download_routeviews_prefix2as(output_dir: Path, day: date, folders: list):
     ts = day.strftime("%Y/%m")
     for folder in folders:
         dir_url = f"https://publicdata.caida.org/datasets/routing/{folder}/{ts}/"
-        prfx2as_url = list(
-            filter(
-                lambda url: day.strftime("-%Y%m%d-") in url, links_in_folder(dir_url)
-            )
-        )[0]
+        try:
+            prfx2as_url = list(
+                filter(
+                    lambda url: day.strftime("%Y%m%d.") in url, links_in_folder(dir_url)
+                )
+            )[0]
+        # if no links are found for this folder, skip it and continue
+        except IndexError:
+            continue
         # We strip from the end of the filepath the hourly timestamp so we can access the files more easily
         dst_filename = Path(
             "-".join(os.path.basename(prfx2as_url).split("-")[:3])

--- a/download_assets.py
+++ b/download_assets.py
@@ -132,7 +132,9 @@ def links_in_folder(url: str):
     assert url.endswith("/")
     resp = req_session.get(url)
     tree = html.fromstring(resp.text)
-    return [f"{url}{href}" for href in tree.xpath("//a[@href]/text()")[5:]]
+    links = [f"{url}{href}" for href in tree.xpath("//a[@href]/text()")[5:]]
+    print(f"links_in_folder: {url} contains:\n {[link for link in links]}")
+    return links
 
 
 def iter_as_org_urls(since, until) -> Generator[str, None, None]:

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ tomli==2.4.0
 tqdm==4.67.3
 typing_extensions==4.15.0
 urllib3==2.6.3
+whoisit==4.0.4


### PR DESCRIPTION
approx 135 records from https://publicdata.caida.org/datasets/routing/routeviews-prefix2as/ have "latest" as a "changed" record, which does not parse, and does not accurately reflect the information available from whois. This patch performs a query when the field is "latest" and uses the response value instead if it is available.