### PR TITLE
Fix as orgs latest

### DIFF
--- a/download_assets.py
+++ b/download_assets.py
@@ -144,7 +144,7 @@ def iter_as_org_urls(since, until) -> Generator[str, None, None]:
         except ValueError:
             # handle inconsistent timestamps, like "latest"
             print(f"skipping {url}")
-            pass
+            continue
         if ts <= until and ts >= since:
             yield url
 

--- a/download_assets.py
+++ b/download_assets.py
@@ -180,11 +180,15 @@ def download_routeviews_prefix2as(output_dir: Path, day: date, folders: list):
     ts = day.strftime("%Y/%m")
     for folder in folders:
         dir_url = f"https://publicdata.caida.org/datasets/routing/{folder}/{ts}/"
-        prfx2as_url = list(
-            filter(
-                lambda url: day.strftime("-%Y%m%d-") in url, links_in_folder(dir_url)
-            )
-        )[0]
+        try:
+            prfx2as_url = list(
+                filter(
+                    lambda url: day.strftime("-%Y%m%d-") in url, links_in_folder(dir_url)
+                )
+            )[0]
+        # if no links are found for this folder, skip it and continue
+        except IndexError:
+            continue
         # We strip from the end of the filepath the hourly timestamp so we can access the files more easily
         dst_filename = Path(
             "-".join(os.path.basename(prfx2as_url).split("-")[:3])

--- a/download_assets.py
+++ b/download_assets.py
@@ -4,7 +4,7 @@ import shutil
 import hashlib
 from collections import namedtuple
 from pathlib import Path
-from datetime import datetime, date, timezone
+from datetime import datetime, date, timezone, timedelta
 from typing import Generator, List
 import xml.etree.ElementTree as ET
 
@@ -156,8 +156,11 @@ def download_as_organizations(cache_dir: Path, download_latest: bool):
     since_date = date(2012, 1, 1)
     until_date = datetime.now(timezone.utc).date()
     if download_latest:
-        # Start from the 1st of the current month
-        since_date = until_date.replace(day=1)
+        # It takes about 4 days from the start of the month for the caida data to be published
+        # Include last month if less than seven days have passed
+        since_date = until_date - timedelta(days=7)
+        since_date = since_date.replace(day=1) # the release day is always 1
+        print(f"downloading as_organizations since {since_date} until {until_date}")
 
     for url in iter_as_org_urls(since_date, until_date):
         dst_filename = os.path.basename(url)

--- a/sync_db_ip.py
+++ b/sync_db_ip.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from datetime import datetime, timezone
 from download_assets import list_all_ia_items
 
-import boto3
+import boto3, botocore
 import requests
 import internetarchive as ia
 
@@ -122,13 +122,16 @@ def main():
             access_key=access_key,
             secret_key=secret_key,
         )
-        upload_to_s3(
-            prefix="dbip-country-lite",
-            filepath=filepath,
-            bucket_name=s3_bucket_name,
-            access_key=s3_access_key,
-            secret_key=s3_secret_key,
-        )
+        try:
+            upload_to_s3(
+                prefix="dbip-country-lite",
+                filepath=filepath,
+                bucket_name=s3_bucket_name,
+                access_key=s3_access_key,
+                secret_key=s3_secret_key,
+            )
+        except botocore.exceptions.NoCredentialsError:
+            pass
 
 
 if __name__ == "__main__":

--- a/sync_db_ip.py
+++ b/sync_db_ip.py
@@ -28,15 +28,29 @@ def download_dbip(cache_dir: Path, ts: str) -> Path:
     output_dir = cache_dir / "dbip-country-lite"
     output_dir.mkdir(parents=True, exist_ok=True)
     output_path = output_dir / filename
+    tmp_path = output_path.with_suffix(output_path.suffix + ".tmp")
     print(f"   downloading latest db IP file to {output_path}")
     with requests.get(
         f"https://download.db-ip.com/free/{filename}", stream=True
     ) as resp:
         resp.raise_for_status()
-        with output_path.with_suffix(".tmp").open("wb") as out_file:
+
+        # Skip if file already exists and we can verify matching size.
+        remote_len = resp.headers.get("Content-Length")
+        if output_path.exists() and remote_len is not None:
+            try:
+                remote_len_int = int(remote_len)
+                if output_path.stat().st_size == remote_len_int:
+                    print(f"skipping existing file {output_path}")
+                    return output_path
+            except (ValueError, OSError):
+                pass
+
+        with tmp_path.open("wb") as out_file:
             for b in resp.iter_content(chunk_size=2**16):
                 out_file.write(b)
-    output_path.with_suffix(".tmp").rename(output_path)
+
+    tmp_path.rename(output_path)
     return output_path
 
 


### PR DESCRIPTION
collection of fixes:
* ignore upload_to_s3 failure (for local testing)
* fix as_organizations url filter so it actually skips 'latest' file
* skip re-downloading dbip-country-lite file each time if it exists
* skip missing routeviews_prefix2as datasets if they do not exist