### PR TITLE
skip as-organizations/latest

### DIFF
--- a/download_assets.py
+++ b/download_assets.py
@@ -144,7 +144,7 @@ def iter_as_org_urls(since, until) -> Generator[str, None, None]:
         except ValueError:
             # handle inconsistent timestamps, like "latest"
             print(f"skipping {url}")
-            pass
+            continue
         if ts <= until and ts >= since:
             yield url
 


### PR DESCRIPTION
https://publicdata.caida.org/datasets/as-organizations/ started to include a 'latest' file at some point, and the URL filter did not actually skip it, which resulted in the DAY_STR being set as the 'changed' value when there is no such record